### PR TITLE
Add More IO Functions to How to Participate Docs

### DIFF
--- a/docs/sphinx/source/participating.rst
+++ b/docs/sphinx/source/participating.rst
@@ -149,55 +149,98 @@ Here is Python code that may be useful for getting a set of all the JSON filenam
 
 .. code-block:: python
 
-   # these modules are part of the Python standard library
-   import json
-   import pathlib
+    # these modules are part of the Python standard library
+    import json
+    import pathlib
+
+    # these modules are installed
+    import numpy as np
+    import pandas as pd
 
 
-   def get_test_set_filepaths():
-       """
-       Returns a set of pathlib.Path objects pointing to the JSON test set
-       files. pathlib.Path objects can be passed directly to Python's ``open``
-       function to open the JSON file.
-       """
-       path_to_test_sets = pathlib.Path.cwd() / '..' / '..' / 'test_sets'
-       return {path_to_test_sets / f'{entry.stem}.json'
-               for entry in path_to_test_sets.iterdir()
-               if entry.is_file()}
+    def get_test_set_filepaths():
+        """
+        Returns a sorted list of pathlib.Path objects pointing to the JSON test set
+        files. pathlib.Path objects can be passed directly to Python's ``open``
+        function to open the JSON file.
+
+        Returns
+        -------
+            A list.
+        """
+        path_to_test_sets = pathlib.Path.cwd() / '..' / '..' / 'test_sets'
+        file_entries = list({path_to_test_sets / f'{entry.stem}.json'
+                             for entry in path_to_test_sets.iterdir()
+                             if entry.is_file()})
+        file_entries.sort()
+        return file_entries
 
 
-   def get_test_set_name(filepath):
-       """
-       Gets a test set filename from a filepath.
+    def get_test_set_name(filepath):
+        """
+        Gets a test set filename from a filepath.
 
-       Parameters
-       ----------
-       filepath : pathlib.Path
-           A filepath pointing to a JSON test set file.
-       
-       Returns
-       -------
-           The test set name given a pathlib.Path object pointing to a JSON
-           test set file.
-       """
-       return filepath.stem
+        Parameters
+        ----------
+        filepath : pathlib.Path
+            A filepath pointing to a JSON test set file.
+
+        Returns
+        -------
+            The test set name given a pathlib.Path object pointing to a JSON
+            test set file.
+        """
+        return filepath.stem
 
 
-   def json_file_to_dict(filepath):
-       """
-       Returns a Python dict of the contents of a JSON file.
+    def json_file_to_df(filepath):
+        """
+        Creates a pandas DataFrame from an IV Curve JSON file.
+        All of the numerical values stored as strings in the JSON as parsed to
+        np.float64.
 
-       Parameters
-       ----------
-       filepath : pathlib.Path
-           The filepath pointing to a JSON file.
-       
-       Returns
-       -------
-           A Python dict
-       """
-       with open(filepath, 'r') as file:
-           return json.load(file)
+        Parameters
+        ----------
+        filepath : pathlib.Path
+            A Path object pointing to the JSON file.
+
+        Returns
+        -------
+            A pandas DataFrame.
+        """
+        df = pd.read_json(filepath)
+        df = pd.DataFrame(df['IV Curves'].values.tolist())
+      
+        # set up index
+        df['Index'] = df['Index'].astype(int)
+        df = df.set_index('Index')
+      
+        # convert Voltages and Currents from string array to float array
+        for s in ['Voltages', 'Currents']:
+            df[s] = df[s].apply(lambda a: np.asarray(a, dtype=np.float64))
+      
+        # convert from string to float
+        for d in ['v_oc', 'i_sc', 'v_mp', 'i_mp', 'p_mp', 'Temperature']:
+            df[d] = df[d].apply(np.float64)
+      
+        return df
+
+
+    def json_file_to_dict(filepath):
+        """
+        Returns a Python dict of the contents of a JSON file.
+
+        Parameters
+        ----------
+        filepath : pathlib.Path
+            The filepath pointing to a JSON file.
+
+        Returns
+        -------
+            A Python dict.
+        """
+        with open(filepath, 'r') as file:
+            return json.load(file)
 
 Writing Test Set Results to CSV Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/sphinx/source/participating.rst
+++ b/docs/sphinx/source/participating.rst
@@ -154,14 +154,48 @@ Here is Python code that may be useful for getting a set of all the JSON filenam
    import pathlib
 
 
-   def get_test_set_filenames():
-       path_to_test_sets = pathlib.Path('../../test_sets')
-       return {f'{path_to_test_sets}/{entry.stem}.json'
+   def get_test_set_filepaths():
+       """
+       Returns a set of pathlib.Path objects pointing to the JSON test set
+       files. pathlib.Path objects can be passed directly to Python's ``open``
+       function to open the JSON file.
+       """
+       path_to_test_sets = pathlib.Path.cwd() / '..' / '..' / 'test_sets'
+       return {path_to_test_sets / f'{entry.stem}.json'
                for entry in path_to_test_sets.iterdir()
                if entry.is_file()}
 
 
+   def get_test_set_name(filepath):
+       """
+       Gets a test set filename from a filepath.
+
+       Parameters
+       ----------
+       filepath : pathlib.Path
+           A filepath pointing to a JSON test set file.
+       
+       Returns
+       -------
+           The test set name given a pathlib.Path object pointing to a JSON
+           test set file.
+       """
+       return filepath.stem
+
+
    def json_file_to_dict(filepath):
+       """
+       Returns a Python dict of the contents of a JSON file.
+
+       Parameters
+       ----------
+       filepath : pathlib.Path
+           The filepath pointing to a JSON file.
+       
+       Returns
+       -------
+           A Python dict
+       """
        with open(filepath, 'r') as file:
            return json.load(file)
 

--- a/docs/sphinx/source/participating.rst
+++ b/docs/sphinx/source/participating.rst
@@ -216,12 +216,12 @@ Here is Python code that may be useful for getting a set of all the JSON filenam
         df = df.set_index('Index')
       
         # convert Voltages and Currents from string array to float array
-        for s in ['Voltages', 'Currents']:
-            df[s] = df[s].apply(lambda a: np.asarray(a, dtype=np.float64))
+        arrs = ['Voltages', 'Currents']
+        df[arrs] = df[arrs].applymap(lambda a: np.asarray(a, dtype=np.float64))
       
         # convert from string to float
-        for d in ['v_oc', 'i_sc', 'v_mp', 'i_mp', 'p_mp', 'Temperature']:
-            df[d] = df[d].apply(np.float64)
+        nums = ['v_oc', 'i_sc', 'v_mp', 'i_mp', 'p_mp', 'Temperature']
+        df[nums] = df[nums].applymap(np.float64)
       
         return df
 

--- a/docs/sphinx/source/participating.rst
+++ b/docs/sphinx/source/participating.rst
@@ -215,7 +215,8 @@ Here is Python code that may be useful for getting a set of all the JSON filenam
         df['Index'] = df['Index'].astype(int)
         df = df.set_index('Index')
       
-        # convert Voltages and Currents from string array to float array
+        # convert Voltages and Currents from string array to float array.
+        # this truncates from precise values to 64-bit precision.
         arrs = ['Voltages', 'Currents']
         df[arrs] = df[arrs].applymap(lambda a: np.asarray(a, dtype=np.float64))
       


### PR DESCRIPTION
Includes functions for:
- Getting all test set JSON file pointers (`pathlib.Path` objects)
  - Helps competitors work with relative paths in Python.
- Getting a test set name from its file pointer (calls `pathlib.Path.stem`)
  - Helps competitors create their output CSV files with the correct names.
- Creating a pandas DataFrame of all IV curves in a test set JSON file. All of the numbers stored in strings are parsed to `np.float64`.
  - Helps competitors get the test set JSON data into a usable form.
- Creating a Python dict from the test set JSON file.
  - For competitors who want to decide how to parse the test set JSON data themselves.