### PR TITLE
Fix Pytest workflow when installing ivcurves package.

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ivcurves testing dependencies
-        run: pip3 install .[testing]
+        run: pip3 install -e .[testing]  # the install is editable because the GitHub workflow util .py scripts are not included in the ivcurves package install to site packages
       - name: Run Pytest
         run: pytest ivcurves/tests
 

--- a/.github/workflows/record-scores.yaml
+++ b/.github/workflows/record-scores.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Record scores
     runs-on: ubuntu-latest
     needs: score-submission
-    if: ${{ needs.score-submission.outputs.run-scorer == 'true' && github.event.pull_request.merged == true && github.ref_type == 'branch' && github.ref_name == 'main' && github.repository_owner == 'reepoi' }}
+    if: ${{ needs.score-submission.outputs.run-scorer == 'true' && github.event.pull_request.merged == true && github.ref_type == 'branch' && github.ref_name == 'main' && github.repository_owner == 'cwhanse' }}
     steps:
       - name: Install Python 3.10
         uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ __pycache__
 !ivcurves/ivcurve_jsonschema.json
 !docs/sphinx/source/scores_database.json
 !docs/sphinx/source/scores_database_jsonschema.json
-!test_sets/*.csv
-!test_sets/*.json
+!ivcurves/test_sets/*.csv
+!ivcurves/test_sets/*.json
 !submissions/**/*.*
 
 docs/sphinx/build

--- a/docs/sphinx/source/scores_database_jsonschema.json
+++ b/docs/sphinx/source/scores_database_jsonschema.json
@@ -51,7 +51,7 @@
         },
         "broken": {
           "description": "The submission's code has some error.",
-          "type": "boolean"
+          "type": "string"
         }
       },
       "required": [

--- a/ivcurves/tests/github_workflows/test_record_scores.py
+++ b/ivcurves/tests/github_workflows/test_record_scores.py
@@ -19,11 +19,31 @@ def test_scores_database_pass_jsonschema_validation(scores_database_json, scores
     assert validation_messages['valid']
 
 
-@pytest.mark.parametrize('overall_scores, bad_test_set', [
-    ({'case1': '0', 'case2': '0'}, None),
-    ({'case1': '0'}, 'case2'),
-    ({'case1': 'a', 'case2': '0'}, 'case1')
-])
+def params_test_validate_overall_scores():
+    valid_test_set_filenames = utils.get_filenames_in_directory(utils.TEST_SETS_DIR)
+
+    overall_scores = {name: '0' for name in valid_test_set_filenames}
+
+    test_params = []
+
+    overall_scores1 = overall_scores.copy()
+    test_params.append((overall_scores1, None))  # is valid
+
+    overall_scores2 = overall_scores.copy()
+    test_set_missing = list(overall_scores2.keys())[0]
+    del overall_scores2[test_set_missing]  # remove a test set
+    test_params.append((overall_scores2, test_set_missing))  # missing test set
+
+    overall_scores3 = overall_scores.copy()
+    test_set_NaN_score = list(overall_scores3.keys())[0]
+    overall_scores3[test_set_NaN_score] = 'a'
+    test_params.append((overall_scores3, test_set_NaN_score))
+
+    return test_params
+
+
+@pytest.mark.parametrize('overall_scores, bad_test_set',
+                         params_test_validate_overall_scores())
 def test_validate_overall_scores(overall_scores, bad_test_set):
     is_valid, msg = record_scores.validate_overall_scores(overall_scores)
 

--- a/ivcurves/tests/github_workflows/test_record_scores.py
+++ b/ivcurves/tests/github_workflows/test_record_scores.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import jschon
 import sys
@@ -16,7 +17,7 @@ import record_scores
 def test_scores_database_pass_jsonschema_validation(scores_database_json, scores_database_jsonschema_validator):
     result = scores_database_jsonschema_validator.evaluate(jschon.JSON(scores_database_json))
     validation_messages = result.output('basic')
-    assert validation_messages['valid']
+    assert validation_messages['valid'], json.dumps(validation_messages['errors'], indent=2)
 
 
 def params_test_validate_overall_scores():


### PR DESCRIPTION
In the pytest GitHub workflow, the ivcurves package needs to be installed as editable so that pytest can find the GitHub workflow utility scripts.

Fixing the repository_owner check in the record-scores GitHub workflow.

Updating .gitignore to track the test sets in ivcurves/test_sets.

Change the scores database jsonschema's `broken` property to type `string`. The value of the `broken` key is a hint of what caused the error.