### PR TITLE
Validate case3 JSON with schema validator

### DIFF
--- a/ivcurves/build_case3.py
+++ b/ivcurves/build_case3.py
@@ -137,19 +137,7 @@ def _npint_to_int(x):
     return int(x)
 
 
-def _df_to_list(df):
-    ''' Converts a DataFrame to a list for serialization to JSON
-    '''
-    out = []
-    for i in df.index:
-        d = {'Index': i}
-        d.update({c : df.loc[i, c] for c in df.columns})
-        out.append(d)
-    return out
-
-            
-if __name__== '__main__':
-
+def case3_output():
     # two base curves: one at high irradiance, high efficiency, one at low/low
     curve_list = {'case1': [19, 14],
                   'case2': [19, 14]}
@@ -173,6 +161,7 @@ if __name__== '__main__':
 
     seed_idx = 0
 
+    outputs = []
     for case in ['case1', 'case2']:
         filen = case + '.json'
         with open(TEST_SETS_DIR / filen, 'r') as infile:
@@ -186,8 +175,12 @@ if __name__== '__main__':
             base = curves.loc[idx]
             N = len(base['Currents'])
 
-            outdf = pd.DataFrame(index=np.arange(1, iters + 1),
-                                 columns=curves.columns, data=None)
+            outdf = pd.DataFrame(
+                index=np.arange(1, iters + 1),
+                columns=['Index', *curves.columns],
+                data=dict(Index=range(1, iters+1)),
+                dtype=object
+            )
 
             # random values to modify current
             r = np.random.RandomState(seed=seeds[seed_idx]).normal(
@@ -219,19 +212,29 @@ if __name__== '__main__':
 
             outdf['Temperature'] = curves.loc[idx, 'Temperature']
 
+            outdf['Sweep direction'] = ''
+            outdf['Datetime'] = '1970-01-01T00:00:00Z'
+            outdf = outdf.drop(['cells_in_series'], axis=1)
+
             # write json output
             output = {'Manufacturer': '', 'Model': '', 'Serial Number': '',
                       'Module ID': '',  'Description': '', 'Material': '',
                       'cells_in_series': int(params.loc[idx, 'cells_in_series']),
-                      'IV Curves': _df_to_list(outdf)}
-            outfilen = 'case3' + output_suffix[case][idx] + '.json'
-            save_json(output,TEST_SETS_DIR / outfilen)
+                      'IV Curves': outdf.replace(float('NaN'), None).to_dict(orient='records')}
+            outfilen = 'case3' + output_suffix[case][idx]
 
-            # write corresponding csv file
-            csv_df = params[params.index==idx]
-            new_idx = pd.Index(np.arange(1, len(csv_df) + 1), name='Index')
-            csv_df.index = new_idx
-            outfilen = 'case3' + output_suffix[case][idx] + '.csv'
-            with open(TEST_SETS_DIR / outfilen, 'w') as outfile:
-                csv_df.to_csv(outfile, lineterminator='\n')
-                
+            outputs.append((outfilen, params[params.index == idx], output))
+
+    return outputs
+
+
+if __name__ == '__main__':
+    outputs = case3_output()
+    for outfilen, csv_df, output in outputs:
+        save_json(output, TEST_SETS_DIR / f'{outfilen}.json')
+
+        # write corresponding csv file
+        new_idx = pd.Index(np.arange(1, len(csv_df) + 1), name='Index')
+        csv_df.index = new_idx
+        with open(TEST_SETS_DIR / f'{outfilen}.csv', 'w') as outfile:
+            csv_df.to_csv(outfile, lineterminator='\n')

--- a/ivcurves/build_case3.py
+++ b/ivcurves/build_case3.py
@@ -238,3 +238,4 @@ if __name__ == '__main__':
         csv_df.index = new_idx
         with open(TEST_SETS_DIR / f'{outfilen}.csv', 'w') as outfile:
             csv_df.to_csv(outfile, lineterminator='\n')
+

--- a/ivcurves/compare_curves.py
+++ b/ivcurves/compare_curves.py
@@ -9,9 +9,6 @@ from ivcurves.utils import mp
 import ivcurves.utils as utils
 import ivcurves.precise as precise
 
-# Constants
-
-ALL_TEST_SETS = {'case1', 'case2', 'case3a', 'case3b', 'case3c', 'case3d'}
 
 #####################
 # Find intersection #
@@ -324,7 +321,7 @@ def score_parameters(known_curve_params, fitted_curve_params):
 
     score = 0.
     for x, y in zip(known_curve_params, fitted_curve_params):
-        score += _abs_rel_diff(x, y)        
+        score += _abs_rel_diff(x, y)
     return score
 
 
@@ -475,7 +472,7 @@ def get_argparser():
                     'sets.'
     )
     parser.add_argument(
-        'directory', type=Path, 
+        'directory', type=Path,
         help='Directory containing fitted parameter CSV files.')
     parser.add_argument(
         '--test-sets', dest='test_sets', type=str, default='',
@@ -501,7 +498,7 @@ if __name__ == '__main__':
     constants = utils.constants()
     vth, atol = constants['vth'], constants['atol']
 
-    for name in {'case1', 'case2'}.intersection(test_sets_to_score):
+    for name in utils.TEST_SETS_PRECISE.intersection(test_sets_to_score):
         scores[name] = {}
         known_parameter_sets = utils.read_iv_curve_parameter_sets(
             utils.TEST_SETS_DIR / name)
@@ -512,7 +509,7 @@ if __name__ == '__main__':
             scores[name][idx] = score_curve(known_p, fitted_p, vth,
                                             num_compare_pts, atol)
 
-    for name in {'case3a', 'case3b', 'case3c', 'case3d'}.intersection(
+    for name in utils.TEST_SETS_NOISY.intersection(
             test_sets_to_score):
         scores[name] = {}
         known_parameter_sets = utils.read_iv_curve_parameter_sets(
@@ -522,9 +519,10 @@ if __name__ == '__main__':
         for idx, known_p in known_parameter_sets.items():
             fitted_p = fitted_parameter_sets[idx]
             scores[name][idx] = score_parameters(known_p, fitted_p)
-        
-    for name in ALL_TEST_SETS.difference(test_sets_to_score):
-        scores[name] = {0: float('NaN')}
+
+    for name in utils.get_filenames_in_directory(
+            utils.TEST_SETS_DIR).difference(test_sets_to_score):
+        scores[name] = float('NaN')
 
     write_test_set_score_per_curve_csvs(scores, args.csv_output_path)
     write_overall_scores_csv(scores, args.csv_output_path)

--- a/ivcurves/compare_curves.py
+++ b/ivcurves/compare_curves.py
@@ -522,7 +522,7 @@ if __name__ == '__main__':
 
     for name in utils.get_filenames_in_directory(
             utils.TEST_SETS_DIR).difference(test_sets_to_score):
-        scores[name] = float('NaN')
+        scores[name] = {0: float('NaN')}
 
     write_test_set_score_per_curve_csvs(scores, args.csv_output_path)
     write_overall_scores_csv(scores, args.csv_output_path)

--- a/ivcurves/ivcurve_jsonschema.json
+++ b/ivcurves/ivcurve_jsonschema.json
@@ -135,11 +135,11 @@
         },
         "i_x": {
           "description": "",
-          "$ref": "#/$defs/Number"
+          "$ref": "#/$defs/NumberOption"
         },
         "i_xx": {
           "description": "",
-          "$ref": "#/$defs/Number"
+          "$ref": "#/$defs/NumberOption"
         },
         "Temperature": {
           "description": "",

--- a/ivcurves/precise.py
+++ b/ivcurves/precise.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 import pvlib
 import numpy as np
 
@@ -490,7 +491,7 @@ def get_argparser():
         description='Generates precise IV curve data from the parameters of '
                     'the single diode equation.'
     )
-    parser.add_argument('save_json_path', type=str,
+    parser.add_argument('save_json_path', type=Path,
                         help='Saves the test set JSON at the given path.')
     parser.add_argument('--test-set', dest='test_set_filename', type=str,
                         help='Test set filename (excluding file extension) to '
@@ -518,7 +519,7 @@ if __name__ == '__main__':
             if test_set_json_path.exists():
                 test_set_json = utils.load_json(test_set_json_path)
                 test_set_json = build_precise_json(
-                    name, case_parameter_sets, vth, temp_cell, atol, num_pts,
+                    case_parameter_sets, vth, temp_cell, atol, num_pts,
                     test_set_json=test_set_json
                 )
                 utils.save_json(test_set_json, args.save_json_path / f'{name}.json')

--- a/ivcurves/precise.py
+++ b/ivcurves/precise.py
@@ -505,7 +505,7 @@ if __name__ == '__main__':
         test_set_filenames = [args.test_set_filename]
     else:
         # build all precise cases
-        test_set_filenames = ['case1', 'case2']
+        test_set_filenames = utils.TEST_SETS_PRECISE
 
     constants = utils.constants()
     vth, temp_cell, atol, num_pts = (constants['vth'], constants['temp_cell'],

--- a/ivcurves/test_sets/case3a.json
+++ b/ivcurves/test_sets/case3a.json
@@ -320,13 +320,12 @@
       "v_mp": 37.24561614833534,
       "i_mp": 284.8349076366456,
       "p_mp": 284.8349076366456,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 2,
@@ -641,13 +640,12 @@
       "v_mp": 37.25224024390367,
       "i_mp": 284.46986392429744,
       "p_mp": 284.46986392429744,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 3,
@@ -962,13 +960,12 @@
       "v_mp": 37.252121954990244,
       "i_mp": 284.8203496657757,
       "p_mp": 284.8203496657757,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 4,
@@ -1283,13 +1280,12 @@
       "v_mp": 37.2368243667185,
       "i_mp": 285.3238016783705,
       "p_mp": 285.3238016783705,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 5,
@@ -1604,13 +1600,12 @@
       "v_mp": 37.25314299618238,
       "i_mp": 285.1121249395419,
       "p_mp": 285.1121249395419,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 6,
@@ -1925,13 +1920,12 @@
       "v_mp": 37.24773942461685,
       "i_mp": 284.7709806319636,
       "p_mp": 284.7709806319636,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 7,
@@ -2246,13 +2240,12 @@
       "v_mp": 37.26267263175507,
       "i_mp": 285.06411417931713,
       "p_mp": 285.06411417931713,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 8,
@@ -2567,13 +2560,12 @@
       "v_mp": 37.68280822849124,
       "i_mp": 284.64507915901675,
       "p_mp": 284.64507915901675,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 9,
@@ -2888,13 +2880,12 @@
       "v_mp": 37.25863155807783,
       "i_mp": 285.338689894942,
       "p_mp": 285.338689894942,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 10,
@@ -3209,13 +3200,12 @@
       "v_mp": 37.26142129128205,
       "i_mp": 285.394967771862,
       "p_mp": 285.394967771862,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 11,
@@ -3530,13 +3520,12 @@
       "v_mp": 37.689553735207824,
       "i_mp": 284.6415871491218,
       "p_mp": 284.6415871491218,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 12,
@@ -3851,13 +3840,12 @@
       "v_mp": 37.2459732876009,
       "i_mp": 284.60820550619576,
       "p_mp": 284.60820550619576,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 13,
@@ -4172,13 +4160,12 @@
       "v_mp": 37.704533414450346,
       "i_mp": 285.21384357937626,
       "p_mp": 285.21384357937626,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 14,
@@ -4493,13 +4480,12 @@
       "v_mp": 37.70140618576081,
       "i_mp": 284.77289666997757,
       "p_mp": 284.77289666997757,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 15,
@@ -4814,13 +4800,12 @@
       "v_mp": 37.25697466695888,
       "i_mp": 284.1217284150666,
       "p_mp": 284.1217284150666,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 16,
@@ -5135,13 +5120,12 @@
       "v_mp": 37.25657141266068,
       "i_mp": 285.16357975022595,
       "p_mp": 285.16357975022595,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 17,
@@ -5456,13 +5440,12 @@
       "v_mp": 37.70255426867409,
       "i_mp": 284.7904898324553,
       "p_mp": 284.7904898324553,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 18,
@@ -5777,13 +5760,12 @@
       "v_mp": 37.2512742873938,
       "i_mp": 284.89106163345184,
       "p_mp": 284.89106163345184,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 19,
@@ -6098,13 +6080,12 @@
       "v_mp": 37.255834512530114,
       "i_mp": 284.57467522345723,
       "p_mp": 284.57467522345723,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 20,
@@ -6419,13 +6400,12 @@
       "v_mp": 37.259004662715405,
       "i_mp": 284.719747578642,
       "p_mp": 284.719747578642,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 21,
@@ -6740,13 +6720,12 @@
       "v_mp": 37.252733895021514,
       "i_mp": 284.96723086288165,
       "p_mp": 284.96723086288165,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 22,
@@ -7061,13 +7040,12 @@
       "v_mp": 37.70135938088095,
       "i_mp": 285.1628888783512,
       "p_mp": 285.1628888783512,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 23,
@@ -7382,13 +7360,12 @@
       "v_mp": 37.688958798217406,
       "i_mp": 284.5051155821075,
       "p_mp": 284.5051155821075,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 24,
@@ -7703,13 +7680,12 @@
       "v_mp": 37.25456222883091,
       "i_mp": 284.8416781844301,
       "p_mp": 284.8416781844301,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 25,
@@ -8024,13 +8000,12 @@
       "v_mp": 37.248374161817665,
       "i_mp": 284.9821281557767,
       "p_mp": 284.9821281557767,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 26,
@@ -8345,13 +8320,12 @@
       "v_mp": 37.670783756708936,
       "i_mp": 284.7423002487032,
       "p_mp": 284.7423002487032,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 27,
@@ -8666,13 +8640,12 @@
       "v_mp": 37.253765171522325,
       "i_mp": 284.8726664633791,
       "p_mp": 284.8726664633791,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 28,
@@ -8987,13 +8960,12 @@
       "v_mp": 37.70378754285955,
       "i_mp": 284.71393959437114,
       "p_mp": 284.71393959437114,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 29,
@@ -9308,13 +9280,12 @@
       "v_mp": 37.68474166264304,
       "i_mp": 285.13879472662984,
       "p_mp": 285.13879472662984,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 30,
@@ -9629,13 +9600,12 @@
       "v_mp": 37.705631653704586,
       "i_mp": 284.8243886842692,
       "p_mp": 284.8243886842692,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 31,
@@ -9950,13 +9920,12 @@
       "v_mp": 37.679513552939525,
       "i_mp": 285.05136099243157,
       "p_mp": 285.05136099243157,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 32,
@@ -10271,13 +10240,12 @@
       "v_mp": 37.262897070089856,
       "i_mp": 284.3591538829256,
       "p_mp": 284.3591538829256,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 33,
@@ -10592,13 +10560,12 @@
       "v_mp": 37.24338219165446,
       "i_mp": 284.4773918558982,
       "p_mp": 284.4773918558982,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 34,
@@ -10913,13 +10880,12 @@
       "v_mp": 37.68003455542853,
       "i_mp": 284.69055854036736,
       "p_mp": 284.69055854036736,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 35,
@@ -11234,13 +11200,12 @@
       "v_mp": 37.705343186818325,
       "i_mp": 284.77989993194,
       "p_mp": 284.77989993194,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 36,
@@ -11555,13 +11520,12 @@
       "v_mp": 37.245919410365694,
       "i_mp": 284.58944141467873,
       "p_mp": 284.58944141467873,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 37,
@@ -11876,13 +11840,12 @@
       "v_mp": 37.704978907756505,
       "i_mp": 284.95921843053736,
       "p_mp": 284.95921843053736,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 38,
@@ -12197,13 +12160,12 @@
       "v_mp": 37.25772471522882,
       "i_mp": 285.1657919634265,
       "p_mp": 285.1657919634265,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 39,
@@ -12518,13 +12480,12 @@
       "v_mp": 37.68200823464764,
       "i_mp": 285.10725272521904,
       "p_mp": 285.10725272521904,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 40,
@@ -12839,13 +12800,12 @@
       "v_mp": 37.25268336935428,
       "i_mp": 285.1077793270291,
       "p_mp": 285.1077793270291,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 41,
@@ -13160,13 +13120,12 @@
       "v_mp": 37.67539989585701,
       "i_mp": 284.87579694673695,
       "p_mp": 284.87579694673695,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 42,
@@ -13481,13 +13440,12 @@
       "v_mp": 37.69881132137832,
       "i_mp": 284.99887614588096,
       "p_mp": 284.99887614588096,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 43,
@@ -13802,13 +13760,12 @@
       "v_mp": 37.68387142179836,
       "i_mp": 284.7716941662265,
       "p_mp": 284.7716941662265,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 44,
@@ -14123,13 +14080,12 @@
       "v_mp": 37.69925568526311,
       "i_mp": 284.83879769652503,
       "p_mp": 284.83879769652503,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 45,
@@ -14444,13 +14400,12 @@
       "v_mp": 37.68843384084267,
       "i_mp": 284.7711898293755,
       "p_mp": 284.7711898293755,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 46,
@@ -14765,13 +14720,12 @@
       "v_mp": 37.682681640405306,
       "i_mp": 284.68681348268115,
       "p_mp": 284.68681348268115,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 47,
@@ -15086,13 +15040,12 @@
       "v_mp": 37.242282869341615,
       "i_mp": 284.56472587742803,
       "p_mp": 284.56472587742803,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 48,
@@ -15407,13 +15360,12 @@
       "v_mp": 37.69526471295042,
       "i_mp": 284.37113118341114,
       "p_mp": 284.37113118341114,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 49,
@@ -15728,13 +15680,12 @@
       "v_mp": 37.236059057268854,
       "i_mp": 284.6721673797802,
       "p_mp": 284.6721673797802,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 50,
@@ -16049,13 +16000,12 @@
       "v_mp": 37.698225505089134,
       "i_mp": 285.27215569705777,
       "p_mp": 285.27215569705777,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     }
   ]
 }

--- a/ivcurves/test_sets/case3b.json
+++ b/ivcurves/test_sets/case3b.json
@@ -320,13 +320,12 @@
       "v_mp": 33.79134043560388,
       "i_mp": 28.08108487836116,
       "p_mp": 28.08108487836116,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 2,
@@ -641,13 +640,12 @@
       "v_mp": 33.78646761650838,
       "i_mp": 28.07487701185331,
       "p_mp": 28.07487701185331,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 3,
@@ -962,13 +960,12 @@
       "v_mp": 33.79303123500737,
       "i_mp": 28.065086688582813,
       "p_mp": 28.065086688582813,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 4,
@@ -1283,13 +1280,12 @@
       "v_mp": 33.80181345837245,
       "i_mp": 28.096343994199692,
       "p_mp": 28.096343994199692,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 5,
@@ -1604,13 +1600,12 @@
       "v_mp": 33.8023679218325,
       "i_mp": 28.117961256383314,
       "p_mp": 28.117961256383314,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 6,
@@ -1925,13 +1920,12 @@
       "v_mp": 33.79049325729899,
       "i_mp": 28.07055034085362,
       "p_mp": 28.07055034085362,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 7,
@@ -2246,13 +2240,12 @@
       "v_mp": 33.79163429088627,
       "i_mp": 28.08736394543754,
       "p_mp": 28.08736394543754,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 8,
@@ -2567,13 +2560,12 @@
       "v_mp": 33.80349948352925,
       "i_mp": 28.081818178171254,
       "p_mp": 28.081818178171254,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 9,
@@ -2888,13 +2880,12 @@
       "v_mp": 33.78706178174736,
       "i_mp": 28.06186366534945,
       "p_mp": 28.06186366534945,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 10,
@@ -3209,13 +3200,12 @@
       "v_mp": 33.8004382937219,
       "i_mp": 28.094679500488944,
       "p_mp": 28.094679500488944,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 11,
@@ -3530,13 +3520,12 @@
       "v_mp": 33.78675044807604,
       "i_mp": 28.085817412005305,
       "p_mp": 28.085817412005305,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 12,
@@ -3851,13 +3840,12 @@
       "v_mp": 33.79138865402433,
       "i_mp": 28.043459678699513,
       "p_mp": 28.043459678699513,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 13,
@@ -4172,13 +4160,12 @@
       "v_mp": 33.78603526718502,
       "i_mp": 28.075678625965715,
       "p_mp": 28.075678625965715,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 14,
@@ -4493,13 +4480,12 @@
       "v_mp": 33.77726542702631,
       "i_mp": 28.09118712779809,
       "p_mp": 28.09118712779809,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 15,
@@ -4814,13 +4800,12 @@
       "v_mp": 33.80562762550257,
       "i_mp": 28.06081168016799,
       "p_mp": 28.06081168016799,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 16,
@@ -5135,13 +5120,12 @@
       "v_mp": 33.783908276758126,
       "i_mp": 28.079994882280502,
       "p_mp": 28.079994882280502,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 17,
@@ -5456,13 +5440,12 @@
       "v_mp": 33.798358629195626,
       "i_mp": 28.069393079120267,
       "p_mp": 28.069393079120267,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 18,
@@ -5777,13 +5760,12 @@
       "v_mp": 33.795373399280635,
       "i_mp": 28.10480794475917,
       "p_mp": 28.10480794475917,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 19,
@@ -6098,13 +6080,12 @@
       "v_mp": 33.80720091797233,
       "i_mp": 28.060312990786386,
       "p_mp": 28.060312990786386,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 20,
@@ -6419,13 +6400,12 @@
       "v_mp": 33.80312987412096,
       "i_mp": 28.068710012689685,
       "p_mp": 28.068710012689685,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 21,
@@ -6740,13 +6720,12 @@
       "v_mp": 33.77659591725134,
       "i_mp": 28.055794487113218,
       "p_mp": 28.055794487113218,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 22,
@@ -7061,13 +7040,12 @@
       "v_mp": 33.77806284820211,
       "i_mp": 28.05641595418913,
       "p_mp": 28.05641595418913,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 23,
@@ -7382,13 +7360,12 @@
       "v_mp": 33.780230594714006,
       "i_mp": 28.036358868725483,
       "p_mp": 28.036358868725483,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 24,
@@ -7703,13 +7680,12 @@
       "v_mp": 33.78957112375199,
       "i_mp": 28.094482361100876,
       "p_mp": 28.094482361100876,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 25,
@@ -8024,13 +8000,12 @@
       "v_mp": 33.80164924791384,
       "i_mp": 28.113894289371718,
       "p_mp": 28.113894289371718,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 26,
@@ -8345,13 +8320,12 @@
       "v_mp": 33.78081279152187,
       "i_mp": 28.105912354251235,
       "p_mp": 28.105912354251235,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 27,
@@ -8666,13 +8640,12 @@
       "v_mp": 33.800514274807654,
       "i_mp": 28.079577924869557,
       "p_mp": 28.079577924869557,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 28,
@@ -8987,13 +8960,12 @@
       "v_mp": 33.78094725083741,
       "i_mp": 28.025841208214615,
       "p_mp": 28.025841208214615,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 29,
@@ -9308,13 +9280,12 @@
       "v_mp": 33.780356291575934,
       "i_mp": 28.0915403826377,
       "p_mp": 28.0915403826377,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 30,
@@ -9629,13 +9600,12 @@
       "v_mp": 33.776402881492544,
       "i_mp": 28.06341177876932,
       "p_mp": 28.06341177876932,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 31,
@@ -9950,13 +9920,12 @@
       "v_mp": 33.77523157228277,
       "i_mp": 28.024536481143837,
       "p_mp": 28.024536481143837,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 32,
@@ -10271,13 +10240,12 @@
       "v_mp": 33.79817373065274,
       "i_mp": 28.04470793195446,
       "p_mp": 28.04470793195446,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 33,
@@ -10592,13 +10560,12 @@
       "v_mp": 33.80132513690876,
       "i_mp": 28.09974108409776,
       "p_mp": 28.09974108409776,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 34,
@@ -10913,13 +10880,12 @@
       "v_mp": 33.79644617288939,
       "i_mp": 28.077402312551225,
       "p_mp": 28.077402312551225,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 35,
@@ -11234,13 +11200,12 @@
       "v_mp": 33.79847257212719,
       "i_mp": 28.103938488735057,
       "p_mp": 28.103938488735057,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 36,
@@ -11555,13 +11520,12 @@
       "v_mp": 33.79249537318384,
       "i_mp": 28.063902670960687,
       "p_mp": 28.063902670960687,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 37,
@@ -11876,13 +11840,12 @@
       "v_mp": 33.79487540240688,
       "i_mp": 28.066586481759465,
       "p_mp": 28.066586481759465,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 38,
@@ -12197,13 +12160,12 @@
       "v_mp": 33.798571899124646,
       "i_mp": 28.10347840257297,
       "p_mp": 28.10347840257297,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 39,
@@ -12518,13 +12480,12 @@
       "v_mp": 33.801048077192185,
       "i_mp": 28.10259069801999,
       "p_mp": 28.10259069801999,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 40,
@@ -12839,13 +12800,12 @@
       "v_mp": 33.776446448298394,
       "i_mp": 28.041553776847305,
       "p_mp": 28.041553776847305,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 41,
@@ -13160,13 +13120,12 @@
       "v_mp": 33.78372406760736,
       "i_mp": 28.01377198239154,
       "p_mp": 28.01377198239154,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 42,
@@ -13481,13 +13440,12 @@
       "v_mp": 33.79053252563921,
       "i_mp": 28.065758568698914,
       "p_mp": 28.065758568698914,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 43,
@@ -13802,13 +13760,12 @@
       "v_mp": 33.8067334572743,
       "i_mp": 28.049904503419075,
       "p_mp": 28.049904503419075,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 44,
@@ -14123,13 +14080,12 @@
       "v_mp": 33.787384174046956,
       "i_mp": 28.048212714178774,
       "p_mp": 28.048212714178774,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 45,
@@ -14444,13 +14400,12 @@
       "v_mp": 33.775318898897595,
       "i_mp": 28.06594818074296,
       "p_mp": 28.06594818074296,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 46,
@@ -14765,13 +14720,12 @@
       "v_mp": 33.797084107545665,
       "i_mp": 28.062463152293816,
       "p_mp": 28.062463152293816,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 47,
@@ -15086,13 +15040,12 @@
       "v_mp": 33.77567326940765,
       "i_mp": 28.072703245481883,
       "p_mp": 28.072703245481883,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 48,
@@ -15407,13 +15360,12 @@
       "v_mp": 33.789272125074866,
       "i_mp": 28.059314862945055,
       "p_mp": 28.059314862945055,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 49,
@@ -15728,13 +15680,12 @@
       "v_mp": 33.78400397683739,
       "i_mp": 28.095338242217032,
       "p_mp": 28.095338242217032,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 50,
@@ -16049,13 +16000,12 @@
       "v_mp": 33.80312573911883,
       "i_mp": 28.048346575732147,
       "p_mp": 28.048346575732147,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     }
   ]
 }

--- a/ivcurves/test_sets/case3c.json
+++ b/ivcurves/test_sets/case3c.json
@@ -320,13 +320,12 @@
       "v_mp": 86.83359508728225,
       "i_mp": 204.17054210910482,
       "p_mp": 204.17054210910482,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 2,
@@ -641,13 +640,12 @@
       "v_mp": 86.81127457790687,
       "i_mp": 203.94381141221726,
       "p_mp": 203.94381141221726,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 3,
@@ -962,13 +960,12 @@
       "v_mp": 86.79714061499034,
       "i_mp": 204.04730281626388,
       "p_mp": 204.04730281626388,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 4,
@@ -1283,13 +1280,12 @@
       "v_mp": 86.85923360072009,
       "i_mp": 203.96199451932972,
       "p_mp": 203.96199451932972,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 5,
@@ -1604,13 +1600,12 @@
       "v_mp": 86.8443635012861,
       "i_mp": 203.950848883031,
       "p_mp": 203.950848883031,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 6,
@@ -1925,13 +1920,12 @@
       "v_mp": 86.78037041161383,
       "i_mp": 203.72480313106865,
       "p_mp": 203.72480313106865,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 7,
@@ -2246,13 +2240,12 @@
       "v_mp": 86.82084170966971,
       "i_mp": 203.93117396053813,
       "p_mp": 203.93117396053813,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 8,
@@ -2567,13 +2560,12 @@
       "v_mp": 86.8248590718691,
       "i_mp": 203.9698546020195,
       "p_mp": 203.9698546020195,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 9,
@@ -2888,13 +2880,12 @@
       "v_mp": 86.78438580395887,
       "i_mp": 204.16633139965387,
       "p_mp": 204.16633139965387,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 10,
@@ -3209,13 +3200,12 @@
       "v_mp": 86.78258363790913,
       "i_mp": 203.69598291160793,
       "p_mp": 203.69598291160793,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 11,
@@ -3530,13 +3520,12 @@
       "v_mp": 86.83491113233416,
       "i_mp": 204.30438247068523,
       "p_mp": 204.30438247068523,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 12,
@@ -3851,13 +3840,12 @@
       "v_mp": 86.81150354749268,
       "i_mp": 204.0274240394876,
       "p_mp": 204.0274240394876,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 13,
@@ -4172,13 +4160,12 @@
       "v_mp": 86.86600136892304,
       "i_mp": 204.2867578583272,
       "p_mp": 204.2867578583272,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 14,
@@ -4493,13 +4480,12 @@
       "v_mp": 86.80776148045781,
       "i_mp": 203.81541246699885,
       "p_mp": 203.81541246699885,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 15,
@@ -4814,13 +4800,12 @@
       "v_mp": 86.79400235894451,
       "i_mp": 204.1143637971164,
       "p_mp": 204.1143637971164,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 16,
@@ -5135,13 +5120,12 @@
       "v_mp": 86.83654435470092,
       "i_mp": 203.8635688382029,
       "p_mp": 203.8635688382029,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 17,
@@ -5456,13 +5440,12 @@
       "v_mp": 86.7815706687152,
       "i_mp": 203.8478575581402,
       "p_mp": 203.8478575581402,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 18,
@@ -5777,13 +5760,12 @@
       "v_mp": 86.849082093183,
       "i_mp": 204.17362033640785,
       "p_mp": 204.17362033640785,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 19,
@@ -6098,13 +6080,12 @@
       "v_mp": 86.85540055657815,
       "i_mp": 204.01407938839102,
       "p_mp": 204.01407938839102,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 20,
@@ -6419,13 +6400,12 @@
       "v_mp": 86.83771031327142,
       "i_mp": 204.08299421378422,
       "p_mp": 204.08299421378422,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 21,
@@ -6740,13 +6720,12 @@
       "v_mp": 86.79089739860896,
       "i_mp": 203.68308917804566,
       "p_mp": 203.68308917804566,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 22,
@@ -7061,13 +7040,12 @@
       "v_mp": 86.832077267243,
       "i_mp": 203.7770524106132,
       "p_mp": 203.7770524106132,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 23,
@@ -7382,13 +7360,12 @@
       "v_mp": 86.86111464774362,
       "i_mp": 204.3211807765733,
       "p_mp": 204.3211807765733,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 24,
@@ -7703,13 +7680,12 @@
       "v_mp": 86.83267211372323,
       "i_mp": 203.95828481929726,
       "p_mp": 203.95828481929726,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 25,
@@ -8024,13 +8000,12 @@
       "v_mp": 86.80866772321293,
       "i_mp": 203.67584999822566,
       "p_mp": 203.67584999822566,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 26,
@@ -8345,13 +8320,12 @@
       "v_mp": 86.85721907639709,
       "i_mp": 204.4626215236902,
       "p_mp": 204.4626215236902,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 27,
@@ -8666,13 +8640,12 @@
       "v_mp": 86.81540037366858,
       "i_mp": 203.58908091030943,
       "p_mp": 203.58908091030943,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 28,
@@ -8987,13 +8960,12 @@
       "v_mp": 86.83388846396342,
       "i_mp": 204.0204096781753,
       "p_mp": 204.0204096781753,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 29,
@@ -9308,13 +9280,12 @@
       "v_mp": 86.84118351051697,
       "i_mp": 204.06407421477726,
       "p_mp": 204.06407421477726,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 30,
@@ -9629,13 +9600,12 @@
       "v_mp": 86.79755584318816,
       "i_mp": 204.4383751914405,
       "p_mp": 204.4383751914405,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 31,
@@ -9950,13 +9920,12 @@
       "v_mp": 86.82471621333374,
       "i_mp": 203.90568007180093,
       "p_mp": 203.90568007180093,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 32,
@@ -10271,13 +10240,12 @@
       "v_mp": 86.85910714217631,
       "i_mp": 204.08094938454136,
       "p_mp": 204.08094938454136,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 33,
@@ -10592,13 +10560,12 @@
       "v_mp": 86.83038563353644,
       "i_mp": 204.12686127384083,
       "p_mp": 204.12686127384083,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 34,
@@ -10913,13 +10880,12 @@
       "v_mp": 86.79184745943834,
       "i_mp": 203.73074503542068,
       "p_mp": 203.73074503542068,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 35,
@@ -11234,13 +11200,12 @@
       "v_mp": 86.78194315490146,
       "i_mp": 203.87320095616033,
       "p_mp": 203.87320095616033,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 36,
@@ -11555,13 +11520,12 @@
       "v_mp": 86.86105163495668,
       "i_mp": 204.18765976296064,
       "p_mp": 204.18765976296064,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 37,
@@ -11876,13 +11840,12 @@
       "v_mp": 86.81642963996954,
       "i_mp": 203.87765154871786,
       "p_mp": 203.87765154871786,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 38,
@@ -12197,13 +12160,12 @@
       "v_mp": 86.84112229185608,
       "i_mp": 204.2078384857294,
       "p_mp": 204.2078384857294,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 39,
@@ -12518,13 +12480,12 @@
       "v_mp": 86.78510780155275,
       "i_mp": 203.75479269331996,
       "p_mp": 203.75479269331996,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 40,
@@ -12839,13 +12800,12 @@
       "v_mp": 86.79086726175554,
       "i_mp": 204.1759186049749,
       "p_mp": 204.1759186049749,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 41,
@@ -13160,13 +13120,12 @@
       "v_mp": 86.8146598808645,
       "i_mp": 203.66894351792476,
       "p_mp": 203.66894351792476,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 42,
@@ -13481,13 +13440,12 @@
       "v_mp": 86.79735335675313,
       "i_mp": 204.00140885509222,
       "p_mp": 204.00140885509222,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 43,
@@ -13802,13 +13760,12 @@
       "v_mp": 86.81573173624685,
       "i_mp": 203.7169600563183,
       "p_mp": 203.7169600563183,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 44,
@@ -14123,13 +14080,12 @@
       "v_mp": 86.78548816141519,
       "i_mp": 203.8394637291836,
       "p_mp": 203.8394637291836,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 45,
@@ -14444,13 +14400,12 @@
       "v_mp": 86.84870412360608,
       "i_mp": 203.86426781960847,
       "p_mp": 203.86426781960847,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 46,
@@ -14765,13 +14720,12 @@
       "v_mp": 86.84149033324462,
       "i_mp": 204.3940620355054,
       "p_mp": 204.3940620355054,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 47,
@@ -15086,13 +15040,12 @@
       "v_mp": 86.83433716559,
       "i_mp": 204.1552328550493,
       "p_mp": 204.1552328550493,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 48,
@@ -15407,13 +15360,12 @@
       "v_mp": 86.78444540975116,
       "i_mp": 204.09677176941042,
       "p_mp": 204.09677176941042,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 49,
@@ -15728,13 +15680,12 @@
       "v_mp": 86.81287018812948,
       "i_mp": 203.7747815284723,
       "p_mp": 203.7747815284723,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 50,
@@ -16049,13 +16000,12 @@
       "v_mp": 86.81156024385962,
       "i_mp": 204.02358549119654,
       "p_mp": 204.02358549119654,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     }
   ]
 }

--- a/ivcurves/test_sets/case3d.json
+++ b/ivcurves/test_sets/case3d.json
@@ -320,13 +320,12 @@
       "v_mp": 68.69353675988151,
       "i_mp": 18.303656359247505,
       "p_mp": 18.303656359247505,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 2,
@@ -641,13 +640,12 @@
       "v_mp": 68.67124667442567,
       "i_mp": 18.30528643087696,
       "p_mp": 18.30528643087696,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 3,
@@ -962,13 +960,12 @@
       "v_mp": 68.70311281216776,
       "i_mp": 18.31712462985196,
       "p_mp": 18.31712462985196,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 4,
@@ -1283,13 +1280,12 @@
       "v_mp": 67.76552903434002,
       "i_mp": 18.320098118501633,
       "p_mp": 18.320098118501633,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 5,
@@ -1604,13 +1600,12 @@
       "v_mp": 67.77745249044048,
       "i_mp": 18.342594886864624,
       "p_mp": 18.342594886864624,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 6,
@@ -1925,13 +1920,12 @@
       "v_mp": 67.78368506242883,
       "i_mp": 18.343125851905096,
       "p_mp": 18.343125851905096,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 7,
@@ -2246,13 +2240,12 @@
       "v_mp": 68.6607872074363,
       "i_mp": 18.297622125689536,
       "p_mp": 18.297622125689536,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 8,
@@ -2567,13 +2560,12 @@
       "v_mp": 67.76409758848386,
       "i_mp": 18.27360289040108,
       "p_mp": 18.27360289040108,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 9,
@@ -2888,13 +2880,12 @@
       "v_mp": 67.735374725748,
       "i_mp": 18.321723922603493,
       "p_mp": 18.321723922603493,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 10,
@@ -3209,13 +3200,12 @@
       "v_mp": 68.68805219714858,
       "i_mp": 18.330579262624088,
       "p_mp": 18.330579262624088,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 11,
@@ -3530,13 +3520,12 @@
       "v_mp": 68.6953262336115,
       "i_mp": 18.319593491591522,
       "p_mp": 18.319593491591522,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 12,
@@ -3851,13 +3840,12 @@
       "v_mp": 68.69011048857642,
       "i_mp": 18.27699005241633,
       "p_mp": 18.27699005241633,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 13,
@@ -4172,13 +4160,12 @@
       "v_mp": 68.65434250084402,
       "i_mp": 18.312169209617647,
       "p_mp": 18.312169209617647,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 14,
@@ -4493,13 +4480,12 @@
       "v_mp": 67.77653285800652,
       "i_mp": 18.33169408375816,
       "p_mp": 18.33169408375816,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 15,
@@ -4814,13 +4800,12 @@
       "v_mp": 68.68703213113072,
       "i_mp": 18.323010717462495,
       "p_mp": 18.323010717462495,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 16,
@@ -5135,13 +5120,12 @@
       "v_mp": 68.66578945459969,
       "i_mp": 18.305975235349297,
       "p_mp": 18.305975235349297,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 17,
@@ -5456,13 +5440,12 @@
       "v_mp": 67.75684190367365,
       "i_mp": 18.29388582707865,
       "p_mp": 18.29388582707865,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 18,
@@ -5777,13 +5760,12 @@
       "v_mp": 68.67586774152748,
       "i_mp": 18.287661114573613,
       "p_mp": 18.287661114573613,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 19,
@@ -6098,13 +6080,12 @@
       "v_mp": 68.69029920130806,
       "i_mp": 18.31358227016156,
       "p_mp": 18.31358227016156,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 20,
@@ -6419,13 +6400,12 @@
       "v_mp": 67.77477444980885,
       "i_mp": 18.311387691264276,
       "p_mp": 18.311387691264276,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 21,
@@ -6740,13 +6720,12 @@
       "v_mp": 68.66187285053161,
       "i_mp": 18.307998356071096,
       "p_mp": 18.307998356071096,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 22,
@@ -7061,13 +7040,12 @@
       "v_mp": 67.77719780284826,
       "i_mp": 18.33889777656197,
       "p_mp": 18.33889777656197,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 23,
@@ -7382,13 +7360,12 @@
       "v_mp": 68.70063673979826,
       "i_mp": 18.297352187293146,
       "p_mp": 18.297352187293146,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 24,
@@ -7703,13 +7680,12 @@
       "v_mp": 68.64612139714342,
       "i_mp": 18.27550505630878,
       "p_mp": 18.27550505630878,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 25,
@@ -8024,13 +8000,12 @@
       "v_mp": 67.75439186028838,
       "i_mp": 18.30718131440028,
       "p_mp": 18.30718131440028,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 26,
@@ -8345,13 +8320,12 @@
       "v_mp": 68.63985316509606,
       "i_mp": 18.30380836181945,
       "p_mp": 18.30380836181945,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 27,
@@ -8666,13 +8640,12 @@
       "v_mp": 68.69583797525549,
       "i_mp": 18.318429839392273,
       "p_mp": 18.318429839392273,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 28,
@@ -8987,13 +8960,12 @@
       "v_mp": 68.6934854804048,
       "i_mp": 18.309248913548423,
       "p_mp": 18.309248913548423,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 29,
@@ -9308,13 +9280,12 @@
       "v_mp": 67.7654137051748,
       "i_mp": 18.314186033803786,
       "p_mp": 18.314186033803786,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 30,
@@ -9629,13 +9600,12 @@
       "v_mp": 68.69173510132316,
       "i_mp": 18.319533892143177,
       "p_mp": 18.319533892143177,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 31,
@@ -9950,13 +9920,12 @@
       "v_mp": 68.6701694805615,
       "i_mp": 18.305426920070193,
       "p_mp": 18.305426920070193,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 32,
@@ -10271,13 +10240,12 @@
       "v_mp": 68.66174912373778,
       "i_mp": 18.285020200578114,
       "p_mp": 18.285020200578114,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 33,
@@ -10592,13 +10560,12 @@
       "v_mp": 68.69998073110247,
       "i_mp": 18.31781579133828,
       "p_mp": 18.31781579133828,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 34,
@@ -10913,13 +10880,12 @@
       "v_mp": 68.69917492318767,
       "i_mp": 18.320358416257346,
       "p_mp": 18.320358416257346,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 35,
@@ -11234,13 +11200,12 @@
       "v_mp": 67.76849814451037,
       "i_mp": 18.32852364650448,
       "p_mp": 18.32852364650448,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 36,
@@ -11555,13 +11520,12 @@
       "v_mp": 68.68987745966893,
       "i_mp": 18.289788761595638,
       "p_mp": 18.289788761595638,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 37,
@@ -11876,13 +11840,12 @@
       "v_mp": 67.78629630705933,
       "i_mp": 18.31374567655396,
       "p_mp": 18.31374567655396,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 38,
@@ -12197,13 +12160,12 @@
       "v_mp": 67.75720123978094,
       "i_mp": 18.26671862649288,
       "p_mp": 18.26671862649288,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 39,
@@ -12518,13 +12480,12 @@
       "v_mp": 68.69960125370812,
       "i_mp": 18.337237330782337,
       "p_mp": 18.337237330782337,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 40,
@@ -12839,13 +12800,12 @@
       "v_mp": 67.7491070949729,
       "i_mp": 18.323227234112096,
       "p_mp": 18.323227234112096,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 41,
@@ -13160,13 +13120,12 @@
       "v_mp": 68.64397078458448,
       "i_mp": 18.31788985706152,
       "p_mp": 18.31788985706152,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 42,
@@ -13481,13 +13440,12 @@
       "v_mp": 67.74912268089777,
       "i_mp": 18.309825509639463,
       "p_mp": 18.309825509639463,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 43,
@@ -13802,13 +13760,12 @@
       "v_mp": 68.69595624862413,
       "i_mp": 18.318053944973045,
       "p_mp": 18.318053944973045,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 44,
@@ -14123,13 +14080,12 @@
       "v_mp": 68.64264785718514,
       "i_mp": 18.306979126863922,
       "p_mp": 18.306979126863922,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 45,
@@ -14444,13 +14400,12 @@
       "v_mp": 67.78864887878836,
       "i_mp": 18.32845452071912,
       "p_mp": 18.32845452071912,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 46,
@@ -14765,13 +14720,12 @@
       "v_mp": 67.7671193495172,
       "i_mp": 18.305068834224244,
       "p_mp": 18.305068834224244,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 47,
@@ -15086,13 +15040,12 @@
       "v_mp": 67.77424203964162,
       "i_mp": 18.280036746065417,
       "p_mp": 18.280036746065417,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 48,
@@ -15407,13 +15360,12 @@
       "v_mp": 67.76362302603401,
       "i_mp": 18.31458354600107,
       "p_mp": 18.31458354600107,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 49,
@@ -15728,13 +15680,12 @@
       "v_mp": 68.70222665797591,
       "i_mp": 18.30111022052893,
       "p_mp": 18.30111022052893,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     },
     {
       "Index": 50,
@@ -16049,13 +16000,12 @@
       "v_mp": 68.6924505341813,
       "i_mp": 18.32037496399421,
       "p_mp": 18.32037496399421,
-      "i_x": NaN,
-      "i_xx": NaN,
+      "i_x": null,
+      "i_xx": null,
       "Temperature": 298.15,
-      "Irradiance": NaN,
-      "Sweep direction": NaN,
-      "Datetime": NaN,
-      "cells_in_series": NaN
+      "Irradiance": null,
+      "Sweep direction": "",
+      "Datetime": "1970-01-01T00:00:00Z"
     }
   ]
 }

--- a/ivcurves/tests/conftest.py
+++ b/ivcurves/tests/conftest.py
@@ -11,6 +11,7 @@ import scipy
 from ivcurves.utils import mp
 import ivcurves.utils as utils
 import ivcurves.precise as precise
+import ivcurves.build_case3 as build_case3
 
 
 def test_set_to_pandas_df(test_set_parameter_sets, test_set_json):
@@ -96,6 +97,13 @@ def test_set_csv_info_and_json(test_set_csv_info, constants):
         parameter_set, vth, temp_cell, atol, num_pts
     )
     return test_set_csv_info, test_set_json
+
+
+@pytest.fixture(scope='function', params=build_case3.case3_output())
+def test_set_noisy_csv_info_and_json(request):
+    # unpack to indentify to tuple items
+    filename, params_csv_df, test_set_json = request.param
+    return filename, params_csv_df, test_set_json
 
 
 @pytest.fixture()

--- a/ivcurves/tests/test_build_case3.py
+++ b/ivcurves/tests/test_build_case3.py
@@ -1,0 +1,10 @@
+import json
+import jschon
+
+
+def test_test_sets_pass_jsonschema_validation(test_set_noisy_csv_info_and_json,
+                                              ivcurve_jsonschema_validator):
+    _, _, test_set_json = test_set_noisy_csv_info_and_json
+    result = ivcurve_jsonschema_validator.evaluate(jschon.JSON(test_set_json))
+    validation_messages = result.output('basic')
+    assert validation_messages['valid'], json.dumps(validation_messages['errors'], indent=2)

--- a/ivcurves/tests/test_precise.py
+++ b/ivcurves/tests/test_precise.py
@@ -1,6 +1,7 @@
+import json
 import pytest
 import jschon
-from conftest import mp  # same instance of mpmath's mp imported in ivcurves/conftest
+from ivcurves.utils import mp  # same instance of mpmath's mp imported in ivcurves/utils
 import ivcurves.utils as utils
 
 import ivcurves.precise as precise
@@ -10,7 +11,7 @@ def test_test_sets_pass_jsonschema_validation(test_set_json,
                                               ivcurve_jsonschema_validator):
     result = ivcurve_jsonschema_validator.evaluate(jschon.JSON(test_set_json))
     validation_messages = result.output('basic')
-    assert validation_messages['valid']
+    assert validation_messages['valid'], json.dumps(validation_messages['errors'], indent=2)
 
 
 def test_test_sets_precision(test_set_as_pandas_df, constants):

--- a/ivcurves/utils.py
+++ b/ivcurves/utils.py
@@ -8,6 +8,8 @@ from mpmath import mp
 IVCURVES_DIR = Path(__file__).parent
 REPO_ROOT_DIR = IVCURVES_DIR / '..'
 TEST_SETS_DIR = IVCURVES_DIR / 'test_sets'
+TEST_SETS_PRECISE = {'case1', 'case2'}
+TEST_SETS_NOISY = {'case3a', 'case3b', 'case3c', 'case3d'}
 DOCS_DIR = REPO_ROOT_DIR / 'docs' / 'sphinx' / 'source'
 IV_PARAMETER_NAMES = ['photocurrent', 'saturation_current',
                       'resistance_series', 'resistance_shunt', 'n',


### PR DESCRIPTION
Add unit tests to validate that the case3 JSON complies with the ivcurves jsonschema.
To add these unit tests, changes to build_case3.py are made:
- separate the JSON generation from the file saving. This lets the unit tests validate the JSON structure without having to open files.
- Remove `cells_in_series` from the items in the `IV Curves` list.
- Change the `NaN` values to `null`.  `NaN` is a jsonschema number, but the other test sets use `null` for an unknown number value.
- Set `Sweep direction` to empty string.
- Set Datetime to the value used by case1 and case2.

case3 does not include `i_x` and `i_xx` values, so the ivcurves jsonschema is updated to make these optional.

Some refactoring:
- `ivcruves/utils.py` defines the constants `TEST_SETS_PRECISE` and `TEST_SETS_NOISY` since at multiple places in the code case1 and case2 need to be handled differently than case3.