### PR TITLE
Set up Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@ python:
   system_packages: false
   install:
     - method: pip
-      path: -e .
+      path: .
       extra_requirements:
         - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: 3.10
+    python: '3.10'
 
 sphinx:
   fail_on_warning: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: 3.10
+
+sphinx:
+  fail_on_warning: true
+
+python:
+  system_packages: false
+  install:
+    - method: pip
+      path: -e .
+      extra_requirements:
+        - docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
 
 python_requires = >=3.7
 zip_safe = no
-include_package_data = no
+include_package_data = yes
 
 [options.package_data]
 ivcurves =


### PR DESCRIPTION
Add a config file for Read the Docs to automatically build the docs, and provide preview builds of the docs in pull requests.

When building the docs, the `ivcurves` package needs to be installed, and the files in `ivcurves/test_sets` must be available. Since Read the Docs does not support editable installations of `ivcurves`, the files in `ivcurves/test_sets` are now included in the `ivcurves` installation.