### PR TITLE
Run benchmarks against pvfit

### DIFF
--- a/.github/workflows/score-submission.yaml
+++ b/.github/workflows/score-submission.yaml
@@ -2,6 +2,7 @@ name: Score submission
 
 on:
   push:
+  pull_request:
   workflow_call:
     outputs:
       run-scorer:

--- a/submissions/markcampanelli/create_benchmark_data.py
+++ b/submissions/markcampanelli/create_benchmark_data.py
@@ -1,8 +1,8 @@
 """Run unit test from pvfit package to generate fit data."""
 
-import pvfit.tests.modeling.dc.single_diode.equation.inference_test
+import pvfit.modeling.dc.single_diode.equation.inference_test
 import pytest
 
-test_file = pvfit.tests.modeling.dc.single_diode.equation.inference_test.__file__
-
-pytest.main(["-vvsx", "--cache-clear", "-k", "not test_fit_benchmark", test_file])
+if __name__ == "__main__":
+    test_file = pvfit.modeling.dc.single_diode.equation.inference_test.__file__
+    pytest.main(["-vvsx", "--cache-clear", "-k", "not test_fit_benchmark", test_file])

--- a/submissions/markcampanelli/create_benchmark_data.py
+++ b/submissions/markcampanelli/create_benchmark_data.py
@@ -1,4 +1,4 @@
-"""Run unit test from pvfit package to generate fit data."""
+"""Run unit test from pvfit package to generate fit data in current directory."""
 
 import pvfit.modeling.dc.single_diode.equation.inference_test
 import pytest

--- a/submissions/markcampanelli/create_benchmark_data.py
+++ b/submissions/markcampanelli/create_benchmark_data.py
@@ -5,4 +5,4 @@ import pytest
 
 if __name__ == "__main__":
     test_file = pvfit.modeling.dc.single_diode.equation.inference_test.__file__
-    pytest.main(["-vvsx", "--cache-clear", "-k", "not test_fit_benchmark", test_file])
+    pytest.main(["-vvsx", "--cache-clear", f"{test_file}::test_fit"])

--- a/submissions/markcampanelli/create_benchmark_data.py
+++ b/submissions/markcampanelli/create_benchmark_data.py
@@ -1,4 +1,4 @@
-"""Run unit test from pvfit package to generate fit data in current directory."""
+"""Run unit test from pvfit package to generate fit data in the current directory."""
 
 import pvfit.modeling.dc.single_diode.equation.inference_test
 import pytest

--- a/submissions/markcampanelli/create_benchmark_data.py
+++ b/submissions/markcampanelli/create_benchmark_data.py
@@ -1,0 +1,8 @@
+"""Run unit test from pvfit package to generate fit data."""
+
+import pvfit.tests.modeling.dc.single_diode.equation.inference_test
+import pytest
+
+test_file = pvfit.tests.modeling.dc.single_diode.equation.inference_test.__file__
+
+pytest.main(["-vvsx", "--cache-clear", "-k", "not test_fit_benchmark", test_file])

--- a/submissions/markcampanelli/pr_config.json
+++ b/submissions/markcampanelli/pr_config.json
@@ -1,6 +1,6 @@
 {
     "RUN_SCORER": true,
     "REQUIREMENTS": "./requirements.txt",
-    "SUBMISSION_MAIN": "./create benchmark_data.py",
+    "SUBMISSION_MAIN": "./create_benchmark_data.py",
 	"TEST_SETS_FOR_SCORING": "case1,case2,case3a,case3b,case3c,case3d"
 }

--- a/submissions/markcampanelli/pr_config.json
+++ b/submissions/markcampanelli/pr_config.json
@@ -2,5 +2,5 @@
     "RUN_SCORER": true,
     "REQUIREMENTS": "./requirements.txt",
     "SUBMISSION_MAIN": "./create_benchmark_data.py",
-	"TEST_SETS_FOR_SCORING": "case1,case2,case3a,case3b,case3c,case3d"
+    "TEST_SETS_FOR_SCORING": "case1,case2,case3a,case3b,case3c,case3d"
 }

--- a/submissions/markcampanelli/pr_config.json
+++ b/submissions/markcampanelli/pr_config.json
@@ -1,5 +1,6 @@
 {
     "RUN_SCORER": true,
     "REQUIREMENTS": "./requirements.txt",
-    "SUBMISSION_MAIN": "./create benchmark_data.py"
+    "SUBMISSION_MAIN": "./create benchmark_data.py",
+	"TEST_SETS_FOR_SCORING": "case1,case2,case3a,case3b,case3c,case3d"
 }

--- a/submissions/markcampanelli/pr_config.json
+++ b/submissions/markcampanelli/pr_config.json
@@ -1,0 +1,5 @@
+{
+    "RUN_SCORER": true,
+    "REQUIREMENTS": "./requirements.txt",
+    "SUBMISSION_MAIN": "./create benchmark_data.py"
+}

--- a/submissions/markcampanelli/requirements.txt
+++ b/submissions/markcampanelli/requirements.txt
@@ -1,1 +1,1 @@
-pvfit[test] @ git+https://github.com/markcampanelli/pvfit@d80ad6a5080bb425125ea24035a146a039c89120
+pvfit[test] @ git+https://github.com/markcampanelli/pvfit@a1909fa08aacaece507d503ddee881914b78adf8

--- a/submissions/markcampanelli/requirements.txt
+++ b/submissions/markcampanelli/requirements.txt
@@ -1,0 +1,1 @@
+pvfit[test] @ git+https://github.com/markcampanelli/pvfit@d80ad6a5080bb425125ea24035a146a039c89120

--- a/submissions/markcampanelli/requirements.txt
+++ b/submissions/markcampanelli/requirements.txt
@@ -1,1 +1,3 @@
-pvfit[test] @ git+https://github.com/markcampanelli/pvfit@a1909fa08aacaece507d503ddee881914b78adf8
+pandas >=2,<3
+pvfit @ git+https://github.com/markcampanelli/pvfit@a1909fa08aacaece507d503ddee881914b78adf8
+pytest>=7,<8

--- a/submissions/markcampanelli/requirements.txt
+++ b/submissions/markcampanelli/requirements.txt
@@ -1,3 +1,3 @@
 pandas >=2,<3
-pvfit @ git+https://github.com/markcampanelli/pvfit@a1909fa08aacaece507d503ddee881914b78adf8
+pvfit @ git+https://github.com/markcampanelli/pvfit@ceb8755e92af2b426418eb137e1f97c9c796b0fc
 pytest>=7,<8


### PR DESCRIPTION
~Waiting on https://github.com/cwhanse/ivcurves/pull/54 before asking to merge this.~ Added that PR's change here, and it seems to work.

Computational note: For the cases with several noisy I-V curves were generated from the same parameters, this code returns the average parameters for all the individual curve fits, where the fit parallel (shunt) conductances are first averaged THEN converted to the shunt resistance by inverting.

~Also address https://github.com/cwhanse/ivcurves/issues/53 via https://github.com/cwhanse/ivcurves/pull/54.~